### PR TITLE
Add rep claiming logic

### DIFF
--- a/remappings.txt
+++ b/remappings.txt
@@ -1,0 +1,7 @@
+ERC1155/=lib/hats-protocol/lib/ERC1155/
+council/=lib/council/contracts/
+ds-test/=lib/forge-std/lib/ds-test/src/
+forge-std/=lib/forge-std/src/
+hats-protocol/=lib/hats-protocol/src/
+solbase/=lib/hats-protocol/lib/solbase/src/
+utils/=lib/hats-protocol/lib/utils/

--- a/src/HatsHighCouncilVotingVault.sol
+++ b/src/HatsHighCouncilVotingVault.sol
@@ -6,41 +6,140 @@ import { IHats } from "hats-protocol/Interfaces/IHats.sol";
 import { IVotingVault } from "council/interfaces/IVotingVault.sol";
 
 contract HatsHighCouncilVotingVault is IVotingVault {
-  /// @dev Scales up the hat balance to match voting power from ERC20-like values;
-  uint256 internal constant SCALING_FACTOR = 10**18;
+  /*//////////////////////////////////////////////////////////////
+                          CUSTOM ERRORS
+  //////////////////////////////////////////////////////////////*/
+
+  error AlreadyRep();
+  error NotVotingRepHatWearer();
+
+  /*//////////////////////////////////////////////////////////////
+                          PUBLIC CONSTANTS
+  //////////////////////////////////////////////////////////////*/
+
+  /// @notice The Hats Protocol contract
+  IHats public immutable HATS;
+
+  /*//////////////////////////////////////////////////////////////
+                          INTERNAL CONSTANTS
+  //////////////////////////////////////////////////////////////*/
+
+  /// @dev The ERC20-like value for a single vote;
+  uint256 internal constant ONE_VOTE = 10 ** 18;
   /// @dev The pattern of a member DAO voting rep hat, i.e. hat 87.1.x.1
   uint256 internal constant PATTERN = 0x00000057_0001_0000_0001_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000;
   /// @dev The mask for a member DAO voting rep hat
   uint256 internal constant MASK = 0xFFFFFFFF_FFFF_0000_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF;
-  /// @notice The Hats Protocol contract
-  IHats public immutable HATS;
+
+  /*//////////////////////////////////////////////////////////////
+                            DATA MODELS
+  //////////////////////////////////////////////////////////////*/
+
+  struct VotingRep {
+    address rep;
+    uint256 setAt; // block number
+  }
+
+  /*//////////////////////////////////////////////////////////////
+                            MUTABLE STATE
+  //////////////////////////////////////////////////////////////*/
+
+  mapping(uint256 votingRepHat => VotingRep rep) public votingReps;
+
+  /*//////////////////////////////////////////////////////////////
+                            CONSTRUCTOR
+  //////////////////////////////////////////////////////////////*/
 
   constructor(IHats hats) {
     HATS = hats;
   }
 
+  /*//////////////////////////////////////////////////////////////
+                      IVOTINGVAULT FUNCTION
+  //////////////////////////////////////////////////////////////*/
+
   /// @inheritdoc IVotingVault
-  function queryVotePower(address user, uint256 /* blockNumber */, bytes calldata extraData)// forgefmt: disable-line
+  function queryVotePower(address _user, uint256 _blockNumber, bytes calldata _extraData)// forgefmt: disable-line
     external
     view
     override
     returns (uint256)
   {
-    /// @dev `extraData` is the abi-encoded id of `user`'s Member DAO Voting Rep hat
-    uint256 votingHat = abi.decode(extraData, (uint256));
+    /// @dev `extraData` is the abi-encoded id of `_user`'s Member DAO Voting Rep hat
+    uint256 votingHat = abi.decode(_extraData, (uint256));
 
-    if (isVotingRepHat(votingHat)) {
-      // hat balances are either 0 or 1
-      return HATS.balanceOf(user, votingHat) * SCALING_FACTOR;
-    } else {
-      return 0;
-    }
+    /**
+     * @dev `_user` only has voting power if...
+     * 1. `votingHat` is a valid Member DAO voting rep hat (i.e. it matches `PATTERN`)
+     * 2. They are currently wearing `votingHat`
+     * 3. And have been set as the rep for `votingHat` since before `_blockNumber`
+     */
+    return isVotingRep(_user, votingHat, _blockNumber) ? ONE_VOTE : 0;
   }
 
-  /// @notice Checks if `hatId` is a member DAO voting rep hat
-  /// @param hatId The id of the hat to check
-  /// @return True if `hatId` is a member DAO voting rep hat
-  function isVotingRepHat(uint256 hatId) public pure returns (bool) {
-    return (hatId & MASK) == PATTERN;
+  /*//////////////////////////////////////////////////////////////
+                          PUBLIC FUNCTIONS
+  //////////////////////////////////////////////////////////////*/
+
+  /**
+   * @notice Sets `_user` as the rep for a given Member DAO voting rep hat
+   * @dev `_user` must be wearing `votingRepHat`, which must be a valid Member DAO voting rep hat
+   * @param _user The address to set as the rep
+   * @param _votingRepHat The id of the hat to set the rep for
+   */
+  function setVotingRep(address _user, uint256 _votingRepHat) public {
+    // `_user` must be wearing `votingRepHat`, which must be a valid Member DAO voting rep hat
+    if (!wearsVotingRepHat(_user, _votingRepHat)) revert NotVotingRepHatWearer();
+
+    VotingRep storage rep = votingReps[_votingRepHat];
+    // `_user` must not already be the rep
+    if (rep.rep == _user) revert AlreadyRep();
+    // set `_user` as the rep, and record the block number
+    rep.rep = _user;
+    rep.setAt = block.number;
+  }
+
+  /**
+   * @notice Claims rep status for a given Member DAO voting rep hat
+   * @dev `msg.sender` must be wearing `votingRepHat`, which must be a valid Member DAO voting rep hat
+   * @param _votingRepHat The id of the hat to set the rep for
+   */
+  function claimVotingPower(uint256 _votingRepHat) external {
+    setVotingRep(msg.sender, _votingRepHat);
+  }
+
+  /*//////////////////////////////////////////////////////////////
+                          PUBLIC GETTERS
+  //////////////////////////////////////////////////////////////*/
+  /**
+   * @notice Checks if `_hatId` is a valid Member DAO voting rep hat
+   * @param _hatId The id of the hat to check
+   * @return True if `_hatId` is a member DAO voting rep hat
+   */
+  function isVotingRepHat(uint256 _hatId) public pure returns (bool) {
+    return (_hatId & MASK) == PATTERN;
+  }
+
+  /**
+   * @notice Checks if an address is wearing a valid Member DAO voting rep hat
+   * @param _user The address to check
+   * @param _hatId The id of the hat to check
+   * @return True if `_hatId` is a valid Member DAO voting rep and, and `_user` is wearing it
+   */
+  function wearsVotingRepHat(address _user, uint256 _hatId) public view returns (bool) {
+    return isVotingRepHat(_hatId) && HATS.isWearerOfHat(_user, _hatId);
+  }
+
+  /**
+   * @notice Checks if an address is a valid Member DAO voting rep, relative to a given `_blockNumber`
+   * @param _user The address to check
+   * @param _hatId The id of the hat to check
+   * @param _blockNumber The block number to check
+   * @return True if `_hatId` is a valid Member DAO voting rep, `_user` is currently wearing it, and has been set as the
+   * rep since before `_blockNumber`
+   */
+  function isVotingRep(address _user, uint256 _hatId, uint256 _blockNumber) public view returns (bool) {
+    VotingRep storage rep = votingReps[_hatId];
+    return wearsVotingRepHat(_user, _hatId) && (rep.rep == _user) && (rep.setAt < _blockNumber);
   }
 }

--- a/test/HatsHighCouncilVotingVault.t.sol
+++ b/test/HatsHighCouncilVotingVault.t.sol
@@ -11,8 +11,25 @@ contract HHCVVTest is Deploy, Test {
   // IHats public hats;
   // uint256 public membershipDomain;
 
-  uint256 public fork;
-  uint256 public BLOCK_NUMBER;
+  // uint256 public fork;
+  // uint256 public BLOCK_NUMBER;
+
+  uint256 public hat;
+  uint256 public MATCHING_HAT = 0x00000057_0001_0001_0001_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000;
+  uint256 public NON_MATCHING_HAT = 0x00000056_0001_0001_0001_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000;
+
+  address public user = makeAddr("user");
+  address public user2 = makeAddr("user2");
+  address public rep;
+  uint256 public since; // block number
+  uint256 public since2; // block number
+  uint256 public propBlock; // proposal block number
+  uint256 public constant ONE_VOTE = 10 ** 18;
+
+  error AlreadyRep();
+  error NotWearingVotingRepHat();
+
+  event NewVotingRep(address newRep, address prevRep, uint256 votingRepHat);
 
   function setUp() public virtual {
     // create and activate a fork, at BLOCK_NUMBER
@@ -22,51 +39,426 @@ contract HHCVVTest is Deploy, Test {
     Deploy.prepare(false);
     Deploy.run();
   }
+
+  function setRep(address _user) public {
+    // it is a voting rep hat
+    hat = MATCHING_HAT;
+    // user is wearing it
+    vm.mockCall(address(hats), abi.encodeWithSelector(hats.isWearerOfHat.selector, _user, hat), abi.encode(true));
+    // set the rep
+    hhcvv.setVotingRep(_user, hat);
+  }
 }
 
 contract IsVotingRepHat is HHCVVTest {
-  uint256 testValue;
-
   function testFuzz_matchesPattern_true(uint16 id) public {
     vm.assume(id > 0);
-    testValue = 0x00000057_0001_0000_0001_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000 + (uint256(id) << 192);
-    console2.log(testValue);
-    assertTrue(hhcvv.isVotingRepHat(testValue));
+    hat = 0x00000057_0001_0000_0001_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000 + (uint256(id) << 192);
+    console2.log(hat);
+    assertTrue(hhcvv.isVotingRepHat(hat));
   }
 
   function testFuzz_tooChildy_false(uint160 id) public {
     vm.assume(id > 0);
-    testValue = 0x00000057_0001_0001_0001_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000 + uint256(id);
-    console2.log(testValue);
-    assertFalse(hhcvv.isVotingRepHat(testValue));
+    hat = 0x00000057_0001_0001_0001_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000 + uint256(id);
+    console2.log(hat);
+    assertFalse(hhcvv.isVotingRepHat(hat));
   }
 
   function testFuzz_wrongTopHat_false(uint32 id) public {
     vm.assume(id != 87);
-    testValue = 0x00000000_0001_0001_0001_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000 + (uint256(id) << 224);
-    console2.log(testValue);
-    assertFalse(hhcvv.isVotingRepHat(testValue));
+    hat = 0x00000000_0001_0001_0001_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000 + (uint256(id) << 224);
+    console2.log(hat);
+    assertFalse(hhcvv.isVotingRepHat(hat));
   }
 
   function testFuzz_wrongLevel1Hat_false(uint16 id) public {
     vm.assume(id > 1);
-    testValue = 0x00000057_0000_0001_0001_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000 + (uint256(id) << 208);
-    console2.log(testValue);
-    assertFalse(hhcvv.isVotingRepHat(testValue));
+    hat = 0x00000057_0000_0001_0001_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000 + (uint256(id) << 208);
+    console2.log(hat);
+    assertFalse(hhcvv.isVotingRepHat(hat));
   }
 
   function testFuzz_wrongLevel3Hat_false(uint16 id) public {
     vm.assume(id > 1);
-    testValue = 0x00000057_0001_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000 + (uint256(id) << 176);
-    console2.log(testValue);
-    assertFalse(hhcvv.isVotingRepHat(testValue));
+    hat = 0x00000057_0001_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000 + (uint256(id) << 176);
+    console2.log(hat);
+    assertFalse(hhcvv.isVotingRepHat(hat));
   }
 
   function test_concrete_false() public { }
 }
 
-// TODO:
-// wearsVotingRepHat
-// setVotingRepHat
-// claimVotingPower
-// queryVotePower
+contract WearsVotingRepHat is HHCVVTest {
+  function test_votingRepHat_wearing_true() public {
+    // it is a voting rep hat
+    hat = MATCHING_HAT;
+    // is wearing the hat
+    vm.mockCall(
+      address(hats), abi.encodeWithSelector(hats.isWearerOfHat.selector, address(this), hat), abi.encode(true)
+    );
+
+    assertTrue(hhcvv.wearsVotingRepHat(address(this), hat));
+  }
+
+  function test_votingRepHat_notWearing_false() public {
+    // it is a voting rep hat
+    hat = MATCHING_HAT;
+    // is not wearing the hat
+    vm.mockCall(
+      address(hats), abi.encodeWithSelector(hats.isWearerOfHat.selector, address(this), hat), abi.encode(false)
+    );
+
+    assertFalse(hhcvv.wearsVotingRepHat(address(this), hat));
+  }
+
+  function test_notVotingRepHat_wearing_false() public {
+    // it is not a voting rep hat
+    hat = NON_MATCHING_HAT;
+    // is wearing the hat
+    vm.mockCall(
+      address(hats), abi.encodeWithSelector(hats.isWearerOfHat.selector, address(this), hat), abi.encode(true)
+    );
+
+    assertFalse(hhcvv.wearsVotingRepHat(address(this), hat));
+  }
+
+  function test_notVotingRepHat_notWearing_false() public {
+    // it is not a voting rep hat
+    hat = NON_MATCHING_HAT;
+    // is not wearing the hat
+    vm.mockCall(
+      address(hats), abi.encodeWithSelector(hats.isWearerOfHat.selector, address(this), hat), abi.encode(false)
+    );
+
+    assertFalse(hhcvv.wearsVotingRepHat(address(this), hat));
+  }
+}
+
+contract SetVotingRepHat is HHCVVTest {
+  function test_wearingVotingRepHat_notRep_succeeds() public {
+    // it is a voting rep hat
+    hat = MATCHING_HAT;
+    // user is wearing it
+    vm.mockCall(address(hats), abi.encodeWithSelector(hats.isWearerOfHat.selector, user, hat), abi.encode(true));
+    // user is not already a rep
+    (rep, since) = hhcvv.votingReps(hat);
+    assertFalse(rep == user, "user is already a rep");
+
+    // set the rep, expecting an event
+    vm.expectEmit(true, true, true, true);
+    emit NewVotingRep(user, address(0), hat);
+    hhcvv.setVotingRep(user, hat);
+
+    // user is now the rep
+    (rep, since) = hhcvv.votingReps(hat);
+    assertTrue(rep == user, "user did not become the rep");
+    assertEq(since, block.number, "since was not set to the current block");
+  }
+
+  function test_WearingVotingRepHat_alreadyRep_reverts() public {
+    // it is a voting rep hat
+    hat = MATCHING_HAT;
+    // user is wearing it
+    vm.mockCall(address(hats), abi.encodeWithSelector(hats.isWearerOfHat.selector, user, hat), abi.encode(true));
+    // user is already a rep
+    hhcvv.setVotingRep(user, hat);
+    (rep, since) = hhcvv.votingReps(hat);
+    assertTrue(rep == user, "user is not already a rep");
+
+    // attempt to set the rep, expecting a revert
+    vm.expectRevert(AlreadyRep.selector);
+    hhcvv.setVotingRep(user, hat);
+
+    // ensure the user is still the rep
+    (rep, since2) = hhcvv.votingReps(hat);
+    assertTrue(rep == user, "user is not still the rep");
+    assertEq(since2, since, "since was changed");
+  }
+
+  function test_notWearingVotingRepHat_notRep_reverts() public {
+    // it is not a voting rep hat
+    hat = NON_MATCHING_HAT;
+    // user is not wearing it
+    vm.mockCall(address(hats), abi.encodeWithSelector(hats.isWearerOfHat.selector, user, hat), abi.encode(false));
+    // user is not already a rep
+    (rep, since) = hhcvv.votingReps(hat);
+    assertFalse(rep == user, "user is already a rep");
+
+    // attempt to set the rep, expecting a revert
+    vm.expectRevert(NotWearingVotingRepHat.selector);
+    hhcvv.setVotingRep(user, hat);
+
+    // ensure the user is still not the rep
+    (rep, since2) = hhcvv.votingReps(hat);
+    assertFalse(rep == user, "user is now the rep");
+    assertEq(since2, since, "since was changed");
+  }
+
+  function test_notWearingVotingRepHat_alreadyRep_reverts() public {
+    // it is a voting rep hat
+    hat = MATCHING_HAT;
+    // user is initially wearing the hat
+    vm.mockCall(address(hats), abi.encodeWithSelector(hats.isWearerOfHat.selector, user, hat), abi.encode(true));
+    // user is already a rep
+    hhcvv.setVotingRep(user, hat);
+    (rep, since) = hhcvv.votingReps(hat);
+    assertTrue(rep == user, "user is not already a rep");
+
+    // now user loses the hat
+    vm.mockCall(address(hats), abi.encodeWithSelector(hats.isWearerOfHat.selector, user, hat), abi.encode(false));
+
+    // attempt to set the rep, expecting a revert
+    vm.expectRevert(NotWearingVotingRepHat.selector);
+    hhcvv.setVotingRep(user, hat);
+
+    // ensure the user is still the rep
+    (rep, since2) = hhcvv.votingReps(hat);
+    assertTrue(rep == user, "user is not still the rep");
+    assertEq(since2, since, "since was changed");
+  }
+
+  function test_wearingVotingRepHat_notRep_replacePrevRep_succeeds() public {
+    // it is a voting rep hat
+    hat = MATCHING_HAT;
+    // user is wearing it
+    vm.mockCall(address(hats), abi.encodeWithSelector(hats.isWearerOfHat.selector, user, hat), abi.encode(true));
+    // user is not already a rep
+    (rep, since) = hhcvv.votingReps(hat);
+    assertFalse(rep == user, "user is already a rep");
+
+    // set the rep, expecting an event
+    vm.expectEmit(true, true, true, true);
+    emit NewVotingRep(user, address(0), hat);
+    hhcvv.setVotingRep(user, hat);
+
+    // user is now the rep
+    (rep, since) = hhcvv.votingReps(hat);
+    assertTrue(rep == user, "user did not become the rep");
+
+    // now a user2 is wearing the hat
+
+    vm.mockCall(address(hats), abi.encodeWithSelector(hats.isWearerOfHat.selector, user2, hat), abi.encode(true));
+
+    // set user2 as the new rep, expecting an event
+    vm.expectEmit(true, true, true, true);
+    emit NewVotingRep(user2, user, hat);
+    hhcvv.setVotingRep(user2, hat);
+
+    // user2 is now the rep
+    (rep, since) = hhcvv.votingReps(hat);
+    assertTrue(rep == user2, "user2 did not become the rep");
+    assertEq(since, block.number, "since was changed");
+  }
+}
+
+contract ClaimVotingPower is HHCVVTest {
+  function test_wearingVotingRepHat_notRep_succeeds() public {
+    // it is a voting rep hat
+    hat = MATCHING_HAT;
+    // user is wearing it
+    vm.mockCall(address(hats), abi.encodeWithSelector(hats.isWearerOfHat.selector, user, hat), abi.encode(true));
+    // user is not already a rep
+    (rep, since) = hhcvv.votingReps(hat);
+    assertFalse(rep == user, "user is already a rep");
+
+    // set the rep, expecting an event
+    vm.expectEmit(true, true, true, true);
+    emit NewVotingRep(user, address(0), hat);
+    vm.prank(user);
+    hhcvv.claimVotingPower(hat);
+
+    (rep, since) = hhcvv.votingReps(hat);
+    assertTrue(rep == user, "user did not become the rep");
+    assertEq(since, block.number, "since was not set to the current block");
+  }
+
+  function test_WearingVotingRepHat_alreadyRep_reverts() public {
+    // it is a voting rep hat
+    hat = MATCHING_HAT;
+    // user is wearing it
+    vm.mockCall(address(hats), abi.encodeWithSelector(hats.isWearerOfHat.selector, user, hat), abi.encode(true));
+    // user is already a rep
+    hhcvv.setVotingRep(user, hat);
+    (rep, since) = hhcvv.votingReps(hat);
+    assertTrue(rep == user, "user is not already a rep");
+
+    // attempt to set the rep, expecting a revert
+    vm.expectRevert(AlreadyRep.selector);
+    vm.prank(user);
+    hhcvv.claimVotingPower(hat);
+
+    // ensure the user is still the rep
+    (rep, since2) = hhcvv.votingReps(hat);
+    assertTrue(rep == user, "user is not still the rep");
+    assertEq(since2, since, "since was changed");
+  }
+
+  function test_notWearingVotingRepHat_notRep_reverts() public {
+    // it is not a voting rep hat
+    hat = NON_MATCHING_HAT;
+    // user is not wearing it
+    vm.mockCall(address(hats), abi.encodeWithSelector(hats.isWearerOfHat.selector, user, hat), abi.encode(false));
+    // user is not already a rep
+    (rep, since) = hhcvv.votingReps(hat);
+    assertFalse(rep == user, "user is already a rep");
+
+    // attempt to set the rep, expecting a revert
+    vm.expectRevert(NotWearingVotingRepHat.selector);
+    vm.prank(user);
+    hhcvv.claimVotingPower(hat);
+
+    // ensure the user is still not the rep
+    (rep, since2) = hhcvv.votingReps(hat);
+    assertFalse(rep == user, "user is now the rep");
+    assertEq(since2, since, "since was changed");
+  }
+
+  function test_notWearingVotingRepHat_alreadyRep_reverts() public {
+    // it is a voting rep hat
+    hat = MATCHING_HAT;
+    // user is initially wearing the hat
+    vm.mockCall(address(hats), abi.encodeWithSelector(hats.isWearerOfHat.selector, user, hat), abi.encode(true));
+    // user is already a rep
+    hhcvv.setVotingRep(user, hat);
+    (rep, since) = hhcvv.votingReps(hat);
+    assertTrue(rep == user, "user is not already a rep");
+
+    // now user loses the hat
+    vm.mockCall(address(hats), abi.encodeWithSelector(hats.isWearerOfHat.selector, user, hat), abi.encode(false));
+
+    // attempt to set the rep, expecting a revert
+    vm.expectRevert(NotWearingVotingRepHat.selector);
+    vm.prank(user);
+    hhcvv.claimVotingPower(hat);
+
+    // ensure the user is still the rep
+    (rep, since2) = hhcvv.votingReps(hat);
+    assertTrue(rep == user, "user is not still the rep");
+    assertEq(since2, since, "since was changed");
+  }
+
+  function test_wearingVotingRepHat_notRep_replacePrevRep_succeeds() public {
+    // it is a voting rep hat
+    hat = MATCHING_HAT;
+    // user is wearing it
+    vm.mockCall(address(hats), abi.encodeWithSelector(hats.isWearerOfHat.selector, user, hat), abi.encode(true));
+    // user is not already a rep
+    (rep, since) = hhcvv.votingReps(hat);
+    assertFalse(rep == user, "user is already a rep");
+
+    // set the rep, expecting an event
+    vm.expectEmit(true, true, true, true);
+    emit NewVotingRep(user, address(0), hat);
+    hhcvv.setVotingRep(user, hat);
+
+    // user is now the rep
+    (rep, since) = hhcvv.votingReps(hat);
+    assertTrue(rep == user, "user did not become the rep");
+
+    // now a user2 is wearing the hat
+    vm.mockCall(address(hats), abi.encodeWithSelector(hats.isWearerOfHat.selector, user2, hat), abi.encode(true));
+
+    // set user2 as the new rep, expecting an event
+    vm.expectEmit(true, true, true, true);
+    emit NewVotingRep(user2, user, hat);
+    vm.prank(user2);
+    hhcvv.claimVotingPower(hat);
+
+    // user2 is now the rep
+    (rep, since) = hhcvv.votingReps(hat);
+    assertTrue(rep == user2, "user2 did not become the rep");
+    assertEq(since, block.number, "since was changed");
+  }
+}
+
+contract IsVotingRep is HHCVVTest {
+  function test_wearsRepHat_isRep_sinceBeforeProp_true() public {
+    // user wears the rep hat and is the rep
+    setRep(user);
+
+    // proposal block is after since
+    (rep, since) = hhcvv.votingReps(hat);
+    propBlock = since + 1;
+
+    assertTrue(hhcvv.isVotingRep(user, hat, propBlock), "user is not a voting rep");
+  }
+
+  function test_wearsRepHat_isRep_sinceAtProp_false() public {
+    // user wears the rep hat and is the rep
+    setRep(user);
+
+    // proposal block is at since
+    (rep, since) = hhcvv.votingReps(hat);
+    propBlock = since;
+
+    assertFalse(hhcvv.isVotingRep(user, hat, propBlock), "user is a voting rep");
+  }
+
+  function test_wearsRepHat_isRep_sinceAfterProp_false() public {
+    // user wears the rep hat and is the rep
+    setRep(user);
+
+    // proposal block is before since
+    (rep, since) = hhcvv.votingReps(hat);
+    propBlock = since - 1;
+
+    assertFalse(hhcvv.isVotingRep(user, hat, propBlock), "user is a voting rep");
+  }
+
+  function test_wearsRepHat_notRep_sinceBeforeProp_false() public {
+    // user wears the rep hat but is not the rep
+    vm.mockCall(address(hats), abi.encodeWithSelector(hats.isWearerOfHat.selector, user, hat), abi.encode(true));
+    // proposal block is after since
+    (rep, since) = hhcvv.votingReps(hat);
+    propBlock = since + 1;
+
+    assertFalse(hhcvv.isVotingRep(user, hat, propBlock), "user is a voting rep");
+  }
+
+  function test_doesNotWearRepHat_isRep_sinceBeforeProp_false() public {
+    // user does not wear the rep hat but is the rep
+    setRep(user);
+    vm.mockCall(address(hats), abi.encodeWithSelector(hats.isWearerOfHat.selector, user, hat), abi.encode(false));
+
+    // proposal block is after since
+    (rep, since) = hhcvv.votingReps(hat);
+    propBlock = since + 1;
+
+    assertFalse(hhcvv.isVotingRep(user, hat, propBlock), "user is a voting rep");
+  }
+}
+
+contract QueryVotePower is HHCVVTest {
+  bytes public hatData;
+
+  function test_isVotingRep_oneVote() public {
+    // user wears the rep hat and is the rep
+    setRep(user);
+    // proposal block is after since
+    (rep, since) = hhcvv.votingReps(hat);
+    propBlock = since + 1;
+    // they are the rep
+    assertTrue(hhcvv.isVotingRep(user, hat, propBlock), "user is not a voting rep");
+
+    // abi encode the hat id
+    hatData = abi.encode(hat);
+    // voting power should be 1
+    assertEq(hhcvv.queryVotePower(user, propBlock, hatData), ONE_VOTE, "voting power is not ONE_VOTE");
+  }
+
+  function test_isNotVotingRep_noVotes() public {
+    // user wears the rep hat but is not the rep
+    vm.mockCall(address(hats), abi.encodeWithSelector(hats.isWearerOfHat.selector, user, hat), abi.encode(true));
+    // proposal block is later
+    (rep, since) = hhcvv.votingReps(hat);
+    propBlock = since + 1;
+    // they are not the rep
+    assertFalse(hhcvv.isVotingRep(user, hat, propBlock), "user is a voting rep");
+
+    // abi encode the hat id
+    hatData = abi.encode(hat);
+    // voting power should be 0
+    assertEq(hhcvv.queryVotePower(user, propBlock, hatData), 0, "voting power is not 0");
+  }
+}

--- a/test/HatsHighCouncilVotingVault.t.sol
+++ b/test/HatsHighCouncilVotingVault.t.sol
@@ -42,7 +42,7 @@ contract IsVotingRepHat is HHCVVTest {
   }
 
   function testFuzz_wrongTopHat_false(uint32 id) public {
-    vm.assume(id > 1);
+    vm.assume(id != 87);
     testValue = 0x00000000_0001_0001_0001_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000 + (uint256(id) << 224);
     console2.log(testValue);
     assertFalse(hhcvv.isVotingRepHat(testValue));
@@ -61,4 +61,12 @@ contract IsVotingRepHat is HHCVVTest {
     console2.log(testValue);
     assertFalse(hhcvv.isVotingRepHat(testValue));
   }
+
+  function test_concrete_false() public { }
 }
+
+// TODO:
+// wearsVotingRepHat
+// setVotingRepHat
+// claimVotingPower
+// queryVotePower


### PR DESCRIPTION
Closes an attack vector where a Member DAO could vote multiple times on the same proposal, via the following procedure

1. 1st rep votes
2. Member DAO transfers voting rep hat to 2nd rep
3. 2nd rep votes
4. repeat (2) and (3) as desired

We prevent this by having reps expressly claim their voting power in the voting vault, establishing a checkpoint against which to compare the block number of a given proposal, ensuring that a given voting rep hat can only be used to vote once per proposal.

- [x] add claiming functionality
- [x] add tests for new functionality